### PR TITLE
add default_auto_field

### DIFF
--- a/geomat_content/apps.py
+++ b/geomat_content/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class GeomatContentConfig(AppConfig):
     name = "geomat_content"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
- according to #188 in solid-backend, it is necessary to explicitly set default type for primary key