### PR TITLE
Lkr/configure searchable fields

### DIFF
--- a/geomat_content/models.py
+++ b/geomat_content/models.py
@@ -12,6 +12,11 @@ class MineralType(SolidBaseProfile):
     Defines the mineral type model.
     """
 
+    searchable_fields = [
+        "general_information__name",
+        "general_information__trivial_name",
+    ]
+
     class Meta:
         verbose_name = _("mineral type")
         verbose_name_plural = _("mineral types")

--- a/stone_content/models.py
+++ b/stone_content/models.py
@@ -36,6 +36,13 @@ class ChoiceArrayField(ArrayField):
 
 
 class Stone(SolidBaseProfile):
+
+    searchable_fields = [
+        "general_information__name",
+        "general_information__alt_name",
+        "general_information__eng_name",
+    ]
+
     class Meta:
         verbose_name = _("Stein")
         verbose_name_plural = _("Steine")


### PR DESCRIPTION
With the new design of search functionality, the fields that are supposed to be used for searching are configured in the respective backend for each profile type individually (in this case for stone and mineral). Solid-backend will then check if searchable fields are configured and use them for search, default (if no such fields are set) is name