### PR TITLE
Make treenode information available again

### DIFF
--- a/geomat_content/serializers.py
+++ b/geomat_content/serializers.py
@@ -130,5 +130,5 @@ class MineralTypeSerializer(SolidModelSerializer):
 
     class Meta:
         model = MineralType
-        exclude = ["tree_node"]
+        fields = "__all__"
         depth = 2

--- a/stone_content/serializers.py
+++ b/stone_content/serializers.py
@@ -92,5 +92,5 @@ class StoneSerializer(SolidModelSerializer):
 
     class Meta:
         model = Stone
-        exclude = ["tree_node"]
+        fields = "__all__"
         depth = 1


### PR DESCRIPTION
for lazy-loading to work, it is important to know to which tree node a profile belongs.